### PR TITLE
Add Ability to Run as Full Simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,26 +184,15 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitcoin"
-version = "0.29.2"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
-dependencies = [
- "bech32",
- "bitcoin_hashes 0.11.0",
- "secp256k1 0.24.3",
-]
-
-[[package]]
-name = "bitcoin"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
  "bech32",
  "bitcoin-private",
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "hex_lit",
- "secp256k1 0.27.0",
+ "secp256k1",
  "serde",
 ]
 
@@ -212,12 +201,6 @@ name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -325,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57af6eff15ee3fd7a0e09d0baeab8d33c892a73d97b87248e5f94f4749eacfe1"
 dependencies = [
  "anyhow",
- "bitcoin 0.30.1",
+ "bitcoin",
  "hex",
  "log",
  "prost 0.11.9",
@@ -719,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,11 +883,12 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "lightning"
-version = "0.0.116"
+version = "0.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a0f2155316f1570446a0447c993480673f840748c8ed25bbc59dfc442ac770"
+checksum = "5b0c1f811ae288f86c6767055c55b5f7a721ca1e61bf1897a9ae2ec663e8aba1"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -1596,32 +1586,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "bitcoin_hashes 0.11.0",
- "secp256k1-sys 0.6.1",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes 0.12.0",
- "secp256k1-sys 0.8.1",
+ "bitcoin_hashes",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1716,7 +1687,7 @@ name = "sim-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitcoin 0.30.1",
+ "bitcoin",
  "clap",
  "ctrlc",
  "dialoguer",
@@ -1734,7 +1705,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitcoin 0.30.1",
+ "bitcoin",
  "cln-grpc",
  "csv",
  "expanduser",

--- a/sim-lib/Cargo.toml
+++ b/sim-lib/Cargo.toml
@@ -15,7 +15,7 @@ expanduser = "1.2.2"
 serde = { version="1.0.183", features=["derive"] }
 serde_json = "1.0.104"
 bitcoin = { version = "0.30.1", features=["serde"] }
-lightning = { version = "0.0.116" }
+lightning = { version = "0.0.121" }
 tonic_lnd = { package="fedimint-tonic-lnd", version="0.1.2", features=["lightningrpc", "routerrpc"]}
 tonic = { version = "0.8", features = ["tls", "transport"] }
 async-trait = "0.1.73"

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -27,6 +27,7 @@ mod defined_activity;
 pub mod lnd;
 mod random_activity;
 mod serializers;
+pub mod sim_node;
 #[cfg(test)]
 mod test_utils;
 
@@ -80,6 +81,37 @@ impl std::fmt::Display for NodeId {
                 NodeId::PublicKey(pk) => pk.to_string(),
                 NodeId::Alias(a) => a.to_owned(),
             }
+        )
+    }
+}
+
+/// Represents a short channel ID, expressed as a struct so that we can implement display for the trait.
+#[derive(Debug)]
+pub struct ShortChannelID(u64);
+
+/// Utility function to easily convert from u64 to `ShortChannelID`
+impl From<u64> for ShortChannelID {
+    fn from(value: u64) -> Self {
+        ShortChannelID(value)
+    }
+}
+
+/// Utility function to easily convert `ShortChannelID` into u64
+impl From<ShortChannelID> for u64 {
+    fn from(scid: ShortChannelID) -> Self {
+        scid.0
+    }
+}
+
+/// See https://github.com/lightning/bolts/blob/60de4a09727c20dea330f9ee8313034de6e50594/07-routing-gossip.md#definition-of-short_channel_id.
+impl std::fmt::Display for ShortChannelID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}",
+            (self.0 >> 40) as u32,
+            ((self.0 >> 16) & 0xFFFFFF) as u32,
+            (self.0 & 0xFFFF) as u16,
         )
     }
 }

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for NodeId {
 }
 
 /// Represents a short channel ID, expressed as a struct so that we can implement display for the trait.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub struct ShortChannelID(u64);
 
 /// Utility function to easily convert from u64 to `ShortChannelID`
@@ -165,6 +165,8 @@ pub enum SimulationError {
     FileError,
     #[error("{0}")]
     RandomActivityError(RandomActivityError),
+    #[error("Simulated Network Error: {0}")]
+    SimulatedNetworkError(String),
 }
 
 #[derive(Debug, Error)]

--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for NodeId {
 }
 
 /// Represents a short channel ID, expressed as a struct so that we can implement display for the trait.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShortChannelID(u64);
 
 /// Utility function to easily convert from u64 to `ShortChannelID`

--- a/sim-lib/src/sim_node.rs
+++ b/sim-lib/src/sim_node.rs
@@ -1,6 +1,24 @@
-use bitcoin::secp256k1::PublicKey;
-use lightning::ln::PaymentHash;
+use crate::{LightningError, LightningNode, NodeInfo, PaymentOutcome, PaymentResult};
+use async_trait::async_trait;
+use bitcoin::Network;
+use bitcoin::{
+    hashes::{sha256::Hash as Sha256, Hash},
+    secp256k1::PublicKey,
+};
+use lightning::ln::features::NodeFeatures;
+use lightning::ln::msgs::LightningError as LdkError;
+use lightning::ln::{PaymentHash, PaymentPreimage};
+use lightning::routing::gossip::NetworkGraph;
+use lightning::routing::router::{find_route, PaymentParameters, Route, RouteParameters};
+use lightning::routing::scoring::ProbabilisticScorer;
+use lightning::util::logger::{Level, Logger, Record};
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::select;
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+use tokio::sync::Mutex;
+use triggered::Listener;
 
 use crate::ShortChannelID;
 
@@ -336,5 +354,226 @@ impl SimulatedChannel {
     ) -> Result<(), ForwardingError> {
         self.get_node(forwarding_node)?
             .check_htlc_forward(cltv_delta, amount_msat, fee_msat)
+    }
+}
+
+/// SimNetwork represents a high level network coordinator that is responsible for the task of actually propagating
+/// payments through the simulated network.
+#[async_trait]
+trait SimNetwork: Send + Sync {
+    /// Sends payments over the route provided through the network, reporting the final payment outcome to the sender
+    /// channel provided.
+    fn dispatch_payment(
+        &mut self,
+        source: PublicKey,
+        route: Route,
+        payment_hash: PaymentHash,
+        sender: Sender<Result<PaymentResult, LightningError>>,
+    );
+
+    /// Looks up a node in the simulated network and a list of its channel capacities.
+    async fn lookup_node(&self, node: &PublicKey) -> Result<(NodeInfo, Vec<u64>), LightningError>;
+}
+
+/// A wrapper struct used to implement the LightningNode trait (can be thought of as "the" lightning node). Passes
+/// all functionality through to a coordinating simulation network. This implementation contains both the [`SimNetwork`]
+/// implementation that will allow us to dispatch payments and a read-only NetworkGraph that is used for pathfinding.
+/// While these two could be combined, we re-use the LDK-native struct to allow re-use of their pathfinding logic.
+struct SimNode<'a, T: SimNetwork> {
+    info: NodeInfo,
+    /// The underlying execution network that will be responsible for dispatching payments.
+    network: Arc<Mutex<T>>,
+    /// Tracks the channel that will provide updates for payments by hash.
+    in_flight: HashMap<PaymentHash, Receiver<Result<PaymentResult, LightningError>>>,
+    /// A read-only graph used for pathfinding.
+    pathfinding_graph: Arc<NetworkGraph<&'a WrappedLog>>,
+}
+
+impl<'a, T: SimNetwork> SimNode<'a, T> {
+    /// Creates a new simulation node that refers to the high level network coordinator provided to process payments
+    /// on its behalf. The pathfinding graph is provided separately so that each node can handle its own pathfinding.
+    pub fn new(
+        pubkey: PublicKey,
+        payment_network: Arc<Mutex<T>>,
+        pathfinding_graph: Arc<NetworkGraph<&'a WrappedLog>>,
+    ) -> Self {
+        SimNode {
+            info: node_info(pubkey),
+            network: payment_network,
+            in_flight: HashMap::new(),
+            pathfinding_graph,
+        }
+    }
+}
+
+/// Produces the node info for a mocked node, filling in the features that the simulator requires.
+fn node_info(pubkey: PublicKey) -> NodeInfo {
+    // Set any features that the simulator requires here.
+    let mut features = NodeFeatures::empty();
+    features.set_keysend_optional();
+
+    NodeInfo {
+        pubkey,
+        alias: "".to_string(), // TODO: store alias?
+        features,
+    }
+}
+
+/// Uses LDK's pathfinding algorithm with default parameters to find a path from source to destination, with no
+/// restrictions on fee budget.
+fn find_payment_route(
+    source: &PublicKey,
+    dest: PublicKey,
+    amount_msat: u64,
+    pathfinding_graph: &NetworkGraph<&WrappedLog>,
+) -> Result<Route, LdkError> {
+    let scorer = ProbabilisticScorer::new(Default::default(), pathfinding_graph, &WrappedLog {});
+
+    find_route(
+        source,
+        &RouteParameters {
+            payment_params: PaymentParameters::from_node_id(dest, 0)
+                .with_max_total_cltv_expiry_delta(u32::MAX)
+                // TODO: set non-zero value to support MPP.
+                .with_max_path_count(1)
+                // Allow sending htlcs up to 50% of the channel's capacity.
+                .with_max_channel_saturation_power_of_half(1),
+            final_value_msat: amount_msat,
+            max_total_routing_fee_msat: None,
+        },
+        pathfinding_graph,
+        None,
+        &WrappedLog {},
+        &scorer,
+        &Default::default(),
+        &[0; 32],
+    )
+}
+
+#[async_trait]
+impl<T: SimNetwork> LightningNode for SimNode<'_, T> {
+    fn get_info(&self) -> &NodeInfo {
+        &self.info
+    }
+
+    async fn get_network(&mut self) -> Result<Network, LightningError> {
+        Ok(Network::Regtest)
+    }
+
+    /// send_payment picks a random preimage for a payment, dispatches it in the network and adds a tracking channel
+    /// to our node state to be used for subsequent track_payment calls.
+    async fn send_payment(
+        &mut self,
+        dest: PublicKey,
+        amount_msat: u64,
+    ) -> Result<PaymentHash, LightningError> {
+        // Create a sender and receiver pair that will be used to report the results of the payment and add them to
+        // our internal tracking state along with the chosen payment hash.
+        let (sender, receiver) = channel();
+        let preimage = PaymentPreimage(rand::random());
+        let payment_hash = PaymentHash(Sha256::hash(&preimage.0).to_byte_array());
+
+        // Check for payment hash collision, failing the payment if we happen to repeat one.
+        match self.in_flight.entry(payment_hash) {
+            Entry::Occupied(_) => {
+                return Err(LightningError::SendPaymentError(
+                    "payment hash exists".to_string(),
+                ));
+            },
+            Entry::Vacant(vacant) => {
+                vacant.insert(receiver);
+            },
+        }
+
+        let route = match find_payment_route(
+            &self.info.pubkey,
+            dest,
+            amount_msat,
+            &self.pathfinding_graph,
+        ) {
+            Ok(path) => path,
+            // In the case that we can't find a route for the payment, we still report a successful payment *api call*
+            // and report RouteNotFound to the tracking channel. This mimics the behavior of real nodes.
+            Err(e) => {
+                log::trace!("Could not find path for payment: {:?}.", e);
+
+                if let Err(e) = sender.send(Ok(PaymentResult {
+                    htlc_count: 0,
+                    payment_outcome: PaymentOutcome::RouteNotFound,
+                })) {
+                    log::error!("Could not send payment result: {:?}.", e);
+                }
+
+                return Ok(payment_hash);
+            },
+        };
+
+        // If we did successfully obtain a route, dispatch the payment through the network and then report success.
+        self.network
+            .lock()
+            .await
+            .dispatch_payment(self.info.pubkey, route, payment_hash, sender);
+
+        Ok(payment_hash)
+    }
+
+    /// track_payment blocks until a payment outcome is returned for the payment hash provided, or the shutdown listener
+    /// provided is triggered. This call will fail if the hash provided was not obtained by calling send_payment first.
+    async fn track_payment(
+        &mut self,
+        hash: PaymentHash,
+        listener: Listener,
+    ) -> Result<PaymentResult, LightningError> {
+        match self.in_flight.remove(&hash) {
+            Some(receiver) => {
+                select! {
+                    biased;
+                    _ = listener => Err(
+                        LightningError::TrackPaymentError("shutdown during payment tracking".to_string()),
+                    ),
+
+                    // If we get a payment result back, remove from our in flight set of payments and return the result.
+                    res = receiver => {
+                        res.map_err(|e| LightningError::TrackPaymentError(format!("channel receive err: {}", e)))?
+                    },
+                }
+            },
+            None => Err(LightningError::TrackPaymentError(format!(
+                "payment hash {} not found",
+                hex::encode(hash.0),
+            ))),
+        }
+    }
+
+    async fn get_node_info(&mut self, node_id: &PublicKey) -> Result<NodeInfo, LightningError> {
+        Ok(self.network.lock().await.lookup_node(node_id).await?.0)
+    }
+
+    async fn list_channels(&mut self) -> Result<Vec<u64>, LightningError> {
+        Ok(self
+            .network
+            .lock()
+            .await
+            .lookup_node(&self.info.pubkey)
+            .await?
+            .1)
+    }
+}
+
+/// WrappedLog implements LDK's logging trait so that we can provide pathfinding with a logger that uses our existing
+/// logger.
+pub struct WrappedLog {}
+
+impl Logger for WrappedLog {
+    fn log(&self, record: Record) {
+        match record.level {
+            Level::Gossip => log::trace!("{}", record.args),
+            Level::Trace => log::trace!("{}", record.args),
+            Level::Debug => log::debug!("{}", record.args),
+            // LDK has quite noisy info logging for pathfinding, so we downgrade their info logging to our debug level.
+            Level::Info => log::debug!("{}", record.args),
+            Level::Warn => log::warn!("{}", record.args),
+            Level::Error => log::error!("{}", record.args),
+        }
     }
 }

--- a/sim-lib/src/sim_node.rs
+++ b/sim-lib/src/sim_node.rs
@@ -1,0 +1,192 @@
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::PaymentHash;
+use std::collections::HashMap;
+
+use crate::ShortChannelID;
+
+/// ForwardingError represents the various errors that we can run into when forwarding payments in a simulated network.
+/// Since we're not using real lightning nodes, these errors are not obfuscated and can be propagated to the sending
+/// node and used for analysis.
+#[derive(Debug)]
+pub enum ForwardingError {
+    /// Zero amount htlcs are invalid in the protocol.
+    ZeroAmountHtlc,
+    /// The outgoing channel id was not found in the network graph.
+    ChannelNotFound(ShortChannelID),
+    /// The node pubkey provided was not associated with the channel in the network graph.
+    NodeNotFound(PublicKey),
+    /// The channel has already forwarded an HTLC with the payment hash provided.
+    /// TODO: remove if MPP support is added.
+    PaymentHashExists(PaymentHash),
+    /// An htlc with the payment hash provided could not be found to resolve.
+    PaymentHashNotFound(PaymentHash),
+    /// The forwarding node did not have sufficient outgoing balance to forward the htlc (htlc amount / balance).
+    InsufficientBalance(u64, u64),
+    /// The htlc forwarded is less than the channel's advertised minimum htlc amount (htlc amount / minimum).
+    LessThanMinimum(u64, u64),
+    /// The htlc forwarded is more than the chanenl's advertised maximum htlc amount (htlc amount / maximum).
+    MoreThanMaximum(u64, u64),
+    /// The channel has reached its maximum allowable number of htlcs in flight (total in flight / maximim).
+    ExceedsInFlightCount(u64, u64),
+    /// The forwarded htlc's amount would push the channel over its maximum allowable in flight total
+    /// (total in flight / maximum).
+    ExceedsInFlightTotal(u64, u64),
+    /// The forwarded htlc's cltv expiry exceeds the maximum value used to express block heights in Bitcoin.
+    ExpiryInSeconds(u32, u32),
+    /// The forwarded htlc has insufficient cltv delta for the channel's minimum delta (cltv delta / minimum).
+    InsufficientCltvDelta(u32, u32),
+    /// The forwarded htlc has insufficient fee for the channel's policy (fee / expected fee / base fee / prop fee).
+    InsufficientFee(u64, u64, u64, u64),
+    /// The fee policy for a htlc amount would overflow with the given fee policy (htlc amount / base fee / prop fee).
+    FeeOverflow(u64, u64, u64),
+    /// Sanity check on channel balances failed (node balances / channel capacity).
+    SanityCheckFailed(u64, u64),
+}
+
+/// Represents an in-flight htlc that has been forwarded over a channel that is awaiting resolution.
+#[derive(Copy, Clone)]
+struct Htlc {
+    amount_msat: u64,
+    cltv_expiry: u32,
+}
+
+/// Represents one node in the channel's forwarding policy and restrictions. Note that this doesn't directly map to
+/// a single concept in the protocol, a few things have been combined for the sake of simplicity. Used to manage the
+/// lightning "state machine" and check that HTLCs are added in accordance of the advertised policy.
+#[derive(Clone)]
+pub struct ChannelPolicy {
+    pub pubkey: PublicKey,
+    pub max_htlc_count: u64,
+    pub max_in_flight_msat: u64,
+    pub min_htlc_size_msat: u64,
+    pub max_htlc_size_msat: u64,
+    pub cltv_expiry_delta: u32,
+    pub base_fee: u64,
+    pub fee_rate_prop: u64,
+}
+
+/// Fails with the forwarding error provided if the value provided fails its inequality check.
+macro_rules! fail_forwarding_inequality {
+    ($value_1:expr, $op:tt, $value_2:expr, $error_variant:ident $(, $opt:expr)*) => {
+        if $value_1 $op $value_2 {
+            return Err(ForwardingError::$error_variant(
+                    $value_1,
+                    $value_2
+                    $(
+                        , $opt
+                    )*
+             ));
+        }
+    };
+}
+
+/// The internal state of one side of a simulated channel, including its forwarding parameters. This struct is
+/// primarily responsible for handling our view of what's currently in-flight on the channel, and how much
+/// liquidity we have.
+#[derive(Clone)]
+struct ChannelState {
+    local_balance_msat: u64,
+    in_flight: HashMap<PaymentHash, Htlc>,
+    policy: ChannelPolicy,
+}
+
+impl ChannelState {
+    /// Creates a new channel with local liquidity as allocated by the caller. The responsibility of ensuring that the
+    /// local balance of each side of the channel equals its total capacity is on the caller, as we are only dealing
+    /// with a one-sided view of the channel's state.
+    fn new(policy: ChannelPolicy, local_balance_msat: u64) -> Self {
+        ChannelState {
+            local_balance_msat,
+            in_flight: HashMap::new(),
+            policy,
+        }
+    }
+
+    /// Returns the sum of all the *in flight outgoing* HTLCs on the channel.
+    fn in_flight_total(&self) -> u64 {
+        self.in_flight.values().map(|h| h.amount_msat).sum()
+    }
+
+    /// Checks whether the proposed HTLC abides by the channel policy advertised for using this channel as the
+    /// *outgoing* link in a forward.
+    fn check_htlc_forward(
+        &self,
+        cltv_delta: u32,
+        amt: u64,
+        fee: u64,
+    ) -> Result<(), ForwardingError> {
+        fail_forwarding_inequality!(cltv_delta, <, self.policy.cltv_expiry_delta, InsufficientCltvDelta);
+
+        let expected_fee = amt
+            .checked_mul(self.policy.fee_rate_prop)
+            .and_then(|prop_fee| (prop_fee / 1000000).checked_add(self.policy.base_fee))
+            .ok_or(ForwardingError::FeeOverflow(
+                amt,
+                self.policy.base_fee,
+                self.policy.fee_rate_prop,
+            ))?;
+
+        fail_forwarding_inequality!(
+            fee, <, expected_fee, InsufficientFee, self.policy.base_fee, self.policy.fee_rate_prop
+        );
+
+        Ok(())
+    }
+
+    /// Checks whether the proposed HTLC can be added to the channel as an outgoing HTLC. This requires that we have
+    /// sufficient liquidity, and that the restrictions on our in flight htlc balance and count are not violated by
+    /// the addition of the HTLC. Specification sanity checks (such as reasonable CLTV) are also included, as this
+    /// is where we'd check it in real life.
+    fn check_outgoing_addition(&self, htlc: &Htlc) -> Result<(), ForwardingError> {
+        fail_forwarding_inequality!(htlc.amount_msat, >, self.policy.max_htlc_size_msat, MoreThanMaximum);
+        fail_forwarding_inequality!(htlc.amount_msat, <, self.policy.min_htlc_size_msat, LessThanMinimum);
+        fail_forwarding_inequality!(
+            self.in_flight.len() as u64 + 1, >, self.policy.max_htlc_count, ExceedsInFlightCount
+        );
+        fail_forwarding_inequality!(
+            self.in_flight_total() + htlc.amount_msat, >, self.policy.max_in_flight_msat, ExceedsInFlightTotal
+        );
+        fail_forwarding_inequality!(htlc.amount_msat, >, self.local_balance_msat, InsufficientBalance);
+        fail_forwarding_inequality!(htlc.cltv_expiry, >, 500000000, ExpiryInSeconds);
+
+        Ok(())
+    }
+
+    /// Adds the HTLC to our set of outgoing in-flight HTLCs. [`check_outgoing_addition`] must be called before
+    /// this to ensure that the restrictions on outgoing HTLCs are not violated. Local balance is decreased by the
+    /// HTLC amount, as this liquidity is no longer available.
+    ///
+    /// Note: MPP payments are not currently supported, so this function will fail if a duplicate payment hash is
+    /// reported.
+    fn add_outgoing_htlc(&mut self, hash: PaymentHash, htlc: Htlc) -> Result<(), ForwardingError> {
+        self.check_outgoing_addition(&htlc)?;
+        if self.in_flight.get(&hash).is_some() {
+            return Err(ForwardingError::PaymentHashExists(hash));
+        }
+        self.local_balance_msat -= htlc.amount_msat;
+        self.in_flight.insert(hash, htlc);
+        Ok(())
+    }
+
+    /// Removes the HTLC from our set of outgoing in-flight HTLCs, failing if the payment hash is not found. If the
+    /// HTLC failed, the balance is returned to our local liquidity. Note that this function is not responsible for
+    /// reflecting that the balance has moved to the other side of the channel in the success-case, calling code is
+    /// responsible for that.
+    fn remove_outgoing_htlc(
+        &mut self,
+        hash: &PaymentHash,
+        success: bool,
+    ) -> Result<Htlc, ForwardingError> {
+        match self.in_flight.remove(hash) {
+            Some(v) => {
+                // If the HTLC failed, pending balance returns to local balance.
+                if !success {
+                    self.local_balance_msat += v.amount_msat;
+                }
+
+                Ok(v)
+            },
+            None => Err(ForwardingError::PaymentHashNotFound(*hash)),
+        }
+    }
+}


### PR DESCRIPTION
This PR is a WIP that adds the ability to run SimLN without any real lightning nodes, instead providing "simulated nodes" that copy the the routing policies and liquidity constraints of real nodes. The last commit hard-codes a graph to run this "full simulation" on as an example, whereas in reality we'd load from a json description of the desired topology/policies.

### High Level Overview
Lightning implementations in SimLN are abstracted using the LightningNode: (``https://github.com/bitcoin-dev-project/sim-ln/blob/main/sim-lib/src/lib.rs#L180``) trait. The steps that we follow to support a simulated implementation of this trait (SimNode) are as follows: 
- Run the simulator with a `–from_graph option`, which allows starting the simulator with a graph file (format tbd) that provides channel policies and topology (not included in this PR). 
- Use a single, top-level `SimGraph` struct to manage: 
  - A hashmap of simulated channels available
  - Propagation of payments through the simulated channels
- Implement LightningNode: (``https://github.com/bitcoin-dev-project/sim-ln/blob/main/sim-lib/src/lib.rs#L180``) on a SimNode struct which: 
  - Handles implementation of send/tracking functionality
  - Points to the coordinating `SimGraph` struct to manage payment dispatch.

### Graph Abstraction
Management of payments through the simulated network is separated managed with the following layers:

- SimGraph: high level coordinator that keeps a hashmap of each simulated channel (see below) in the network, along with their forwarding policies. Responsible for coordinating addition/removal of HTLCs as they propagate through the network.
- SimNode: implementation of the LightningNode trait which rely on the SimGraph to propagate payments on their behalf. 

<p align="center">
<img width="568" alt="Screenshot 2024-01-30 at 4 43 35 PM" src="`https://github.com/bitcoin-dev-project/sim-ln/assets/42311294/c4f38583-3aa1-49b3-843a-c4ce7a681ec4">`
</p>

These structs are primarily used to provide send/track payment APIs, receiving updates on the state of their payments from SimGraph.

### Channel State Machine

Implementation of channel state is broken down into three layers:
- Channel Policy: representation of the directional policy of a participant (fees etc)
- Channel State: tracks the “live” state of the outgoing state of the channel
- Simulated Channel: tracks state for each direction of the channel, and high level information

<p align="center">
<img width="716" alt="Screenshot 2024-01-30 at 4 19 13 PM" src="`https://github.com/bitcoin-dev-project/sim-ln/assets/42311294/25126c9b-663f-4516-9c36-396230729151">`
</p>

Each channel state is responsible for handling tracking of liquidity and HTLC limits in one direction, and the simulated channel is responsible for enforcing sanity checks across the channel (eg, that we don’t exceed our capacity).

An example state machine update is provided in the table below:
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-0a21a89f-7fff-4cd6-26e7-27365e6cec71"><div dir="ltr" style="margin-left:0pt;" align="left">
Step | Alice Channel State | Bob Channel State
-- | -- | --
Channel Opened by Alice | Local_balance: 100_000 / In_Flight: nil | Local_balance: 0 / In_Flight: Nil
Alice sends 100 sats to Bob | Local_balance: 999_000 / In_Flight: 100 sats | Local_balance: 0 / In_Flight: Nil
Alice payment succeeds | Local_balance: 999_000 / In_Flight: nil | Local_balance: 100 / In_Flight: Nil
Bob sends 50 sats to Alice | Local_balance: 999_000 / In_Flight: nil | Local_balance: 50 / In_Flight: 50
Bob payment fails | Local_balance: 999_000 / In_Flight: nil | Local_balance: 100 / In_Flight: nil

</div></b>

### tl;dr
<p align="center">
<img width="454" alt="Screenshot 2024-01-30 at 4 01 34 PM" src="`https://github.com/bitcoin-dev-project/sim-ln/assets/42311294/bf7aa216-ab34-4199-ad0a-f6b32268a142">`
</p>

