### PR TITLE
Makes methods that interact with lnd mutable

### DIFF
--- a/sim-lib/src/lib.rs
+++ b/sim-lib/src/lib.rs
@@ -81,12 +81,12 @@ pub trait LightningNode {
     fn get_info(&self) -> &NodeInfo;
     /// Keysend payment worth `amount_msat` from a source node to the destination node.
     async fn send_payment(
-        &self,
+        &mut self,
         dest: PublicKey,
         amount_msat: u64,
     ) -> Result<PaymentHash, LightningError>;
     /// Track a payment with the specified hash.
-    async fn track_payment(&self, hash: PaymentHash) -> Result<(), LightningError>;
+    async fn track_payment(&mut self, hash: PaymentHash) -> Result<(), LightningError>;
 }
 
 #[derive(Clone, Copy)]
@@ -200,7 +200,7 @@ async fn consume_events(
     while let Some(action) = receiver.recv().await {
         match action {
             NodeAction::SendPayment(dest, amt_msat) => {
-                let node = node.lock().await;
+                let mut node = node.lock().await;
                 let payment = node.send_payment(dest, amt_msat);
 
                 match payment.await {


### PR DESCRIPTION
Methods of LndNode that call gRPC methods need to access the client mutably. Our traits for LightningNode were defined not to be mutable, meaning we would need to clone the client mutable for every single method.

Let's keep things simple